### PR TITLE
Feature/group mapping

### DIFF
--- a/src/org/swiftsuspenders/mapping/IInjectionMapping.as
+++ b/src/org/swiftsuspenders/mapping/IInjectionMapping.as
@@ -1,0 +1,47 @@
+package org.swiftsuspenders.mapping {
+	import org.swiftsuspenders.Injector;
+	import org.swiftsuspenders.dependencyproviders.DependencyProvider;
+
+	public interface IInjectionMapping extends ProviderlessMapping
+	{
+		/**
+		 * @copy InjectionMapping#softly()
+		 */
+		function softly() : ProviderlessMapping;
+
+		/**
+		 * @copy InjectionMapping#locally()
+		 */
+		function locally() : ProviderlessMapping;
+
+		/**
+		 * @copy InjectionMapping#toProviderOf()
+		 */
+		function toProviderOf(type : Class, name : String = '') : UnsealedMapping;
+
+		/**
+		 * @copy InjectionMapping#unseal()
+		 */
+		function unseal(key : Object) : IInjectionMapping;
+
+		/**
+		 * @copy InjectionMapping#isSealed()
+		 */
+		function get isSealed() : Boolean;
+
+		/**
+		 * @copy InjectionMapping#setInjector()
+		 */
+		function setInjector(injector : Injector) : IInjectionMapping;
+
+		/**
+		 * @copy InjectionMapping#getProvider()
+		 */
+		function getProvider() : DependencyProvider;
+
+		/**
+		 * @copy InjectionMapping#hasProvider()
+		 */
+		function hasProvider() : Boolean;
+	}
+}

--- a/src/org/swiftsuspenders/mapping/InjectionMapping.as
+++ b/src/org/swiftsuspenders/mapping/InjectionMapping.as
@@ -19,7 +19,7 @@ package org.swiftsuspenders.mapping
 	import org.swiftsuspenders.errors.InjectorError;
 	import org.swiftsuspenders.utils.SsInternal;
 
-	public class InjectionMapping implements ProviderlessMapping, UnsealedMapping
+	public class InjectionMapping implements IInjectionMapping
 	{
 		//----------------------       Private / Protected Properties       ----------------------//
 		private var _type : Class;
@@ -33,6 +33,27 @@ package org.swiftsuspenders.mapping
 		private var _local : Boolean;
 		private var _sealed : Boolean;
 		private var _sealKey : Object;
+		private var _groupName : String;
+
+		//----------------------            Internal Properties             ----------------------//
+		public function get type() : Class
+		{
+			return _type;
+		}
+
+		public function get name() : String
+		{
+			return _name;
+		}
+
+		public function get mappingId() : String
+		{
+			return _mappingId;
+		}
+
+		public function get groupName() : String {
+			return _groupName;
+		}
 
 		//----------------------               Public Methods               ----------------------//
 		public function InjectionMapping(
@@ -184,7 +205,8 @@ package org.swiftsuspenders.mapping
 		 * @throws org.swiftsuspenders.errors.InjectorMissingMappingError when no mapping was found
 		 * for the specified dependency
 		 */
-		public function toProviderOf(type : Class, name:String = ''):UnsealedMapping{
+		public function toProviderOf(type : Class, name : String = '') : UnsealedMapping
+		{
 			const provider : DependencyProvider = _creatingInjector.getMapping(type, name).getProvider();
 			toProvider(provider);
 			return this;
@@ -277,7 +299,7 @@ package org.swiftsuspenders.mapping
 		 *
 		 * @see #seal()
 		 */
-		public function unseal(key : Object) : InjectionMapping
+		public function unseal(key : Object) : IInjectionMapping
 		{
 			if (!_sealed)
 			{
@@ -335,7 +357,7 @@ package org.swiftsuspenders.mapping
 		 *
 		 * @return The <code>InjectionMapping</code> the method is invoked on
 		 */
-		public function setInjector(injector : Injector) : InjectionMapping
+		public function setInjector(injector : Injector) : IInjectionMapping
 		{
 			_sealed && throwSealedError();
 			if (injector == _overridingInjector)
@@ -348,6 +370,11 @@ package org.swiftsuspenders.mapping
 			return this;
 		}
 
+		public function toGroup(name : String) : UnsealedMapping
+		{
+			_groupName = name;
+			return this;
+		}
 
 		//----------------------         Private / Protected Methods        ----------------------//
 		private function mapProvider(provider : DependencyProvider) : void

--- a/src/org/swiftsuspenders/mapping/ProviderlessMapping.as
+++ b/src/org/swiftsuspenders/mapping/ProviderlessMapping.as
@@ -9,7 +9,7 @@ package org.swiftsuspenders.mapping
 {
 	import org.swiftsuspenders.dependencyproviders.DependencyProvider;
 
-	public interface ProviderlessMapping
+	public interface ProviderlessMapping extends UnsealedMapping
 	{
 		/**
 		 * @copy InjectionMapping#toType()
@@ -36,9 +36,5 @@ package org.swiftsuspenders.mapping
 		 */
 		function toProvider(provider : DependencyProvider) : UnsealedMapping;
 
-		/**
-		 * @copy InjectionMapping#seal()
-		 */
-		function seal() : Object;
 	}
 }

--- a/src/org/swiftsuspenders/mapping/UnsealedMapping.as
+++ b/src/org/swiftsuspenders/mapping/UnsealedMapping.as
@@ -13,5 +13,10 @@ package org.swiftsuspenders.mapping
 		 * @copy InjectionMapping#seal()
 		 */
 		function seal() : Object;
+
+		/**
+		 * @copy InjectionMapping#toGroup()
+		 */
+		function toGroup(name : String) : UnsealedMapping;
 	}
 }

--- a/src/org/swiftsuspenders/reflection/ReflectorBase.as
+++ b/src/org/swiftsuspenders/reflection/ReflectorBase.as
@@ -7,6 +7,7 @@
 
 package org.swiftsuspenders.reflection
 {
+	import flash.display.Stage;
 	import flash.utils.Proxy;
 	import flash.utils.getDefinitionByName;
 	import flash.utils.getQualifiedClassName;
@@ -30,7 +31,7 @@ package org.swiftsuspenders.reflection
 			 - int and uint return Number as their constructor
 			 For these, we have to fall back to more verbose ways of getting the constructor.
 			 */
-			if (value is Proxy || value is Number || value is XML || value is XMLList || value is Vector.<*>)
+			if (value is Proxy || value is Number || value is XML || value is XMLList || value is Vector.<*> || value is Stage)
 			{
 				return Class(getDefinitionByName(getQualifiedClassName(value)));
 			}

--- a/test/org/swiftsuspenders/ChildInjectorTests.as
+++ b/test/org/swiftsuspenders/ChildInjectorTests.as
@@ -9,8 +9,7 @@ package org.swiftsuspenders
 {
 	import flexunit.framework.Assert;
 
-	import org.swiftsuspenders.mapping.InjectionMapping;
-
+	import org.swiftsuspenders.mapping.IInjectionMapping;
 	import org.swiftsuspenders.support.injectees.ClassInjectee;
 	import org.swiftsuspenders.support.injectees.childinjectors.ChildInjectorCreatingProvider;
 	import org.swiftsuspenders.support.injectees.childinjectors.InjectorInjectee;
@@ -26,7 +25,6 @@ package org.swiftsuspenders
 	import org.swiftsuspenders.support.types.Clazz;
 	import org.swiftsuspenders.support.types.Interface;
 	import org.swiftsuspenders.utils.SsInternal;
-	import org.swiftsuspenders.dependencyproviders.ClassProvider;
 
 	use namespace SsInternal;
 
@@ -61,13 +59,13 @@ package org.swiftsuspenders
 		{
 			injector.map(RobotFoot);
 
-			var leftFootMapping : InjectionMapping = injector.map(RobotLeg, 'leftLeg');
+			var leftFootMapping : IInjectionMapping = injector.map(RobotLeg, 'leftLeg');
 			var leftChildInjector : Injector = injector.createChildInjector();
 			leftChildInjector.map(RobotAnkle);
 			leftChildInjector.map(RobotFoot).toType(LeftRobotFoot);
 
 			leftFootMapping.setInjector(leftChildInjector);
-			var rightFootMapping : InjectionMapping = injector.map(RobotLeg, 'rightLeg');
+			var rightFootMapping : IInjectionMapping = injector.map(RobotLeg, 'rightLeg');
 			var rightChildInjector : Injector = injector.createChildInjector();
 			rightChildInjector.map(RobotAnkle);
 			rightChildInjector.map(RobotFoot).toType(RightRobotFoot);
@@ -87,13 +85,13 @@ package org.swiftsuspenders
 			injector.map(RobotFoot);
 			injector.map(RobotToes);
 
-			var leftFootMapping : InjectionMapping = injector.map(RobotLeg, 'leftLeg');
+			var leftFootMapping : IInjectionMapping = injector.map(RobotLeg, 'leftLeg');
 			var leftChildInjector : Injector = injector.createChildInjector();
 			leftChildInjector.map(RobotAnkle);
 			leftChildInjector.map(RobotFoot).toType(LeftRobotFoot);
 			leftFootMapping.setInjector(leftChildInjector);
 
-			var rightFootMapping : InjectionMapping = injector.map(RobotLeg, 'rightLeg');
+			var rightFootMapping : IInjectionMapping = injector.map(RobotLeg, 'rightLeg');
 			var rightChildInjector : Injector = injector.createChildInjector();
 			rightChildInjector.map(RobotAnkle);
 			rightChildInjector.map(RobotFoot).toType(RightRobotFoot);
@@ -130,12 +128,12 @@ package org.swiftsuspenders
 			injector.map(RobotFoot);
 			injector.map(RobotToes);
 
-			var leftFootMapping : InjectionMapping = injector.map(RobotLeg, 'leftLeg');
+			var leftFootMapping : IInjectionMapping = injector.map(RobotLeg, 'leftLeg');
 			var leftChildInjector : Injector = injector.createChildInjector();
 			leftChildInjector.map(RobotFoot).toType(LeftRobotFoot);
 			leftFootMapping.setInjector(leftChildInjector);
 
-			var rightFootMapping : InjectionMapping = injector.map(RobotLeg, 'rightLeg');
+			var rightFootMapping : IInjectionMapping = injector.map(RobotLeg, 'rightLeg');
 			var rightChildInjector : Injector = injector.createChildInjector();
 			rightChildInjector.map(RobotFoot).toType(RightRobotFoot);
 			rightFootMapping.setInjector(rightChildInjector);

--- a/test/org/swiftsuspenders/InjectorTests.as
+++ b/test/org/swiftsuspenders/InjectorTests.as
@@ -101,7 +101,6 @@ package org.swiftsuspenders
 		[Test]
 		public function unmap_removes_mapping():void
 		{
-			var injectee:InterfaceInjectee = new InterfaceInjectee();
 			var value:Clazz = new Clazz();
 			injector.map(Interface).toValue(value);
 			Assert.assertTrue(injector.satisfies(Interface));
@@ -1165,7 +1164,7 @@ package org.swiftsuspenders
 		[Test]
 		public function performMappedMappingInjection():void
 		{
-			var mapping : InjectionMapping = injector.map(Interface);
+			var mapping : InjectionMapping = injector.map(Interface) as InjectionMapping;
 			mapping.toSingleton(Clazz);
 			injector.map(Interface2).toProvider(new OtherMappingProvider(mapping));
 			var injectee:MultipleSingletonsOfSameClassInjectee = injector.instantiateUnmapped(MultipleSingletonsOfSameClassInjectee);
@@ -1177,7 +1176,7 @@ package org.swiftsuspenders
 		[Test]
 		public function performMappedNamedMappingInjection():void
 		{
-			var mapping : InjectionMapping = injector.map(Interface);
+			var mapping : InjectionMapping = injector.map(Interface) as InjectionMapping;
 			mapping.toSingleton(Clazz);
 			injector.map(Interface2).toProvider(new OtherMappingProvider(mapping));
 			injector.map(Interface, 'name1').toProvider(new OtherMappingProvider(mapping));
@@ -1276,6 +1275,21 @@ package org.swiftsuspenders
 
 			injector.map(SingletonInjectee).toSingleton(SingletonInjectee, true);
 			Assert.assertTrue("SingletonInjectee#hasInitialized", SingletonInjectee.hasInitialized);
+		}
+
+		[Test]
+		public function unmap_group() : void {
+			var groupName : String = "test";
+			injector.map(Interface, "value").toValue(new Clazz()).toGroup(groupName);
+			injector.map(Interface, "singleton").toSingleton(Clazz).toGroup(groupName);
+			injector.map(Interface).toSingleton(Clazz);
+			Assert.assertTrue(injector.satisfies(Interface, "value"));
+			Assert.assertTrue(injector.satisfies(Interface, "singleton"));
+			Assert.assertTrue(injector.satisfies(Interface));
+			injector.unmapGroup(groupName);
+			Assert.assertFalse("Mapping should be removed", injector.satisfies(Interface, "value"));
+			Assert.assertFalse("Mapping should be removed", injector.satisfies(Interface, "singleton"));
+			Assert.assertTrue("Mapping should exist", injector.satisfies(Interface));
 		}
 	}
 }


### PR DESCRIPTION
Add group mappings, to easy remove several mapping with some common sense. Also introduce `IInjectionMapping` interface to hide inner method from public API.
Example:

``` as3
var groupName : String = "test";
injector.map(Interface, "value").toValue(new Clazz()).toGroup(groupName);
injector.map(Interface, "singleton").toSingleton(Clazz).toGroup(groupName);
injector.map(Interface).toSingleton(Clazz);
```

.... and then just :

``` as3
injector.unmapGroup(groupName);
```

All mapping that hasn't groupName still exist, but those who has already unmaped. IMHO that more handly that creating new context with all environment.
