### PR TITLE
Class description not added to cache.

### DIFF
--- a/src/org/swiftsuspenders/Injector.as
+++ b/src/org/swiftsuspenders/Injector.as
@@ -576,7 +576,7 @@ package org.swiftsuspenders
 		 */
 		public function getTypeDescription(type : Class) : TypeDescription
 		{
-			return _reflector.describeInjections(type);
+            	        return _classDescriptor.getDescription(type);
 		}
 		
 		public function hasMapping(type : Class, name : String = '') : Boolean


### PR DESCRIPTION
Fix issue when class description not added to cache, in case it got by *Injector#getTypeDescription* method.