### PR TITLE
Fix constructor named injections

### DIFF
--- a/src/org/swiftsuspenders/reflection/DescribeTypeJSONReflector.as
+++ b/src/org/swiftsuspenders/reflection/DescribeTypeJSONReflector.as
@@ -248,7 +248,7 @@ package org.swiftsuspenders.reflection
 					for (var j : int = 0; j < parametersCount; j++)
 					{
 						const parameter : Object = parametersList[j];
-						parametersMap[parameter.key] = parametersMap[parameter.key]
+						parametersMap[parameter.key] = parametersMap[parameter.key] != undefined
 							? parametersMap[parameter.key] + ',' + parameter.value
 							: parameter.value;
 					}

--- a/src/org/swiftsuspenders/reflection/DescribeTypeReflector.as
+++ b/src/org/swiftsuspenders/reflection/DescribeTypeReflector.as
@@ -93,9 +93,9 @@ package org.swiftsuspenders.reflection
 			{
 				var parameter : XML = args[i];
 				var key : String = parameter.@key;
-				parametersMap[key] = parametersMap[key]
+				parametersMap[key] = parametersMap[key] != undefined
 					? parametersMap[key] + ',' + parameter.attribute('value')
-					: parameter.attribute('value');
+					: parameter.attribute('value').toString();
 			}
 			return parametersMap;
 		}

--- a/test/org/swiftsuspenders/ReflectorTests.as
+++ b/test/org/swiftsuspenders/ReflectorTests.as
@@ -14,6 +14,7 @@ package org.swiftsuspenders
 	import org.hamcrest.object.notNullValue;
 	import org.swiftsuspenders.reflection.Reflector;
 	import org.swiftsuspenders.support.injectees.InterfaceInjectee;
+	import org.swiftsuspenders.support.injectees.MixedFirstUnnamedParametersConstructorInjectee;
 	import org.swiftsuspenders.support.injectees.NamedInterfaceInjectee;
 	import org.swiftsuspenders.support.injectees.OneNamedParameterConstructorInjectee;
 	import org.swiftsuspenders.support.injectees.OneNamedParameterMethodInjectee;
@@ -239,6 +240,22 @@ package org.swiftsuspenders
 			Assert.assertNotNull("Instance of Clazz should have been injected for Clazz dependency",
 					injectee.getDependency());
 			Assert.assertNotNull("Instance of Clazz should have been injected for Interface dependency",
+					injectee.getDependency2());
+		}
+
+		[Test]
+		public function reflectorCorrectlyCreatesInjectionPointForMixedFirstUnnamedParamsConstructorInjection() : void
+		{
+			const injectionPoint : ConstructorInjectionPoint =
+				reflector.describeInjections(MixedFirstUnnamedParametersConstructorInjectee).ctor;
+			injector.map(Clazz);
+			injector.map(Interface, 'namedDep').toType(Clazz);
+			var injectee:MixedFirstUnnamedParametersConstructorInjectee =
+					MixedFirstUnnamedParametersConstructorInjectee(injectionPoint
+							.createInstance(MixedFirstUnnamedParametersConstructorInjectee, injector));
+			Assert.assertNotNull("Instance of Clazz should have been injected for Clazz dependency",
+					injectee.getDependency());
+			Assert.assertNotNull("Instance of Clazz should have been injected for named Interface parameter",
 					injectee.getDependency2());
 		}
 

--- a/test/org/swiftsuspenders/support/injectees/MixedFirstUnnamedParametersConstructorInjectee.as
+++ b/test/org/swiftsuspenders/support/injectees/MixedFirstUnnamedParametersConstructorInjectee.as
@@ -1,0 +1,49 @@
+/*
+* Copyright (c) 2009 the original author or authors
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+package org.swiftsuspenders.support.injectees
+{
+	import org.swiftsuspenders.support.types.Clazz;
+	import org.swiftsuspenders.support.types.Interface;
+
+	[Inject(name='', name='namedDep')]
+	public class MixedFirstUnnamedParametersConstructorInjectee
+	{
+		private var m_dependency : Clazz;
+		private var m_dependency2 : Interface;
+		
+		public function getDependency() : Clazz
+		{
+			return m_dependency;
+		}
+		public function getDependency2() : Interface
+		{
+			return m_dependency2;
+		}
+		
+		public function MixedFirstUnnamedParametersConstructorInjectee(dependency:Clazz, dependency2:Interface):void
+		{
+			m_dependency = dependency;
+			m_dependency2 = dependency2;
+		}
+	}
+}


### PR DESCRIPTION
Such annotation for constructor injection

`[Inject(name="", name="foo")]`

was parsed incorrectly, resulting in injector trying to put named dependency as the first argument.
I'm sorry, I couldn't run tests here (env is not setup), did fix via Github UI. Would be great if somebody could confirm fix!